### PR TITLE
Refine ai chat ui and source display

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,22 +9,12 @@
   <body>
     <div class="container">
       <header class="header">
-        <div class="location">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 22s7-4.35 7-11a7 7 0 1 0-14 0c0 6.65 7 11 7 11Z" stroke="currentColor" stroke-width="1.5"/><circle cx="12" cy="11" r="3" stroke="currentColor" stroke-width="1.5"/></svg>
+        <div class="clock">
           <span id="clockText" class="clock-time"></span>
-          <span class="availability-badge">
-            <span class="dot status-dot--available"></span>
-            <span class="availability-tooltip">Online</span>
-          </span>
         </div>
         <div class="header-right">
-          <button id="spotlightTrigger" class="spotlight-trigger" aria-label="Open command palette">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
-            <span class="spotlight-trigger-text">Search</span>
-            <span class="spotlight-trigger-shortcut"><kbd>⌘</kbd><kbd>K</kbd></span>
-          </button>
           <button id="themeSwitch" class="theme-switch" aria-label="Toggle theme">
-            <svg class="theme-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <svg class="theme-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <circle class="sun-circle" cx="12" cy="12" r="5"></circle>
               <path class="moon-path" d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
               <g class="sun-rays">
@@ -48,13 +38,20 @@
       </section>
 
       <form id="searchForm" class="message-bar" autocomplete="off">
-        <div class="input-affordance" style="position:relative;">
-          <input id="queryInput" class="message-input" type="text" placeholder="Type a message" aria-label="Message" />
-          <button id="voiceBtn" type="button" class="voice-btn" aria-label="Voice input">
-            <svg class="social-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 1a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3Z"/><path d="M19 10a7 7 0 0 1-14 0"/><line x1="12" y1="19" x2="12" y2="23"/></svg>
-          </button>
+        <div class="input-affordance">
+          <div class="input-left-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+          </div>
+          <input id="queryInput" class="message-input" type="text" placeholder="Ask anything" aria-label="Message" />
+          <div class="input-actions">
+            <button id="voiceBtn" type="button" class="voice-btn" aria-label="Voice input">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 1a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3Z"/><path d="M19 10a7 7 0 0 1-14 0"/><line x1="12" y1="19" x2="12" y2="23"/></svg>
+            </button>
+            <button id="submitBtn" class="submit-btn" type="submit" aria-label="Search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+            </button>
+          </div>
         </div>
-        <button id="submitBtn" class="submit-btn" type="submit">Send</button>
       </form>
 
       <div class="quick-actions" aria-label="Quick actions">


### PR DESCRIPTION
Refactor the header to display only the time and mode switcher, and integrate voice and search buttons directly into the input field for a cleaner UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-a722bad1-0e9b-40b6-a90b-611b7c0b4309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a722bad1-0e9b-40b6-a90b-611b7c0b4309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

